### PR TITLE
fix babel runtime related errors

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": ["es2015", "stage-2"],
   "plugins": [
-    ["add-module-exports"],
+    "transform-runtime",
+    "add-module-exports"
   ],
   "env": {
     "test": {

--- a/example/example.js
+++ b/example/example.js
@@ -4,12 +4,24 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _promise = require('babel-runtime/core-js/promise');
+
+var _promise2 = _interopRequireDefault(_promise);
+
+var _regenerator = require('babel-runtime/regenerator');
+
+var _regenerator2 = _interopRequireDefault(_regenerator);
+
+var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
+
+var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
+
 // -- helpers for this example
 
 var _cleanupOldTestDatabases = function () {
-  var _ref3 = _asyncToGenerator(regeneratorRuntime.mark(function _callee2() {
+  var _ref3 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2() {
     var dbList, drops;
-    return regeneratorRuntime.wrap(function _callee2$(_context2) {
+    return _regenerator2.default.wrap(function _callee2$(_context2) {
       while (1) {
         switch (_context2.prev = _context2.next) {
           case 0:
@@ -24,7 +36,7 @@ var _cleanupOldTestDatabases = function () {
               return r.dbDrop(dbName);
             });
             _context2.next = 6;
-            return Promise.all(drops);
+            return _promise2.default.all(drops);
 
           case 6:
           case 'end':
@@ -40,8 +52,8 @@ var _cleanupOldTestDatabases = function () {
 }();
 
 var _createTestDatabaseAndTable = function () {
-  var _ref4 = _asyncToGenerator(regeneratorRuntime.mark(function _callee3() {
-    return regeneratorRuntime.wrap(function _callee3$(_context3) {
+  var _ref4 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee3() {
+    return _regenerator2.default.wrap(function _callee3$(_context3) {
       while (1) {
         switch (_context3.prev = _context3.next) {
           case 0:
@@ -75,17 +87,15 @@ var _lib2 = _interopRequireDefault(_lib);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; } /* eslint-disable no-console, camelcase */
-
-
+/* eslint-disable no-console, camelcase */
 var TMP_DB_NAME_PREFIX = '_changefeedReconnectTest_';
 var tmpDbName = '' + TMP_DB_NAME_PREFIX + Date.now();
 var tableName = 'changefeedItems';
 var r = (0, _rethinkdbdash2.default)({ servers: { host: 'localhost', port: 28015 }, silent: true });
 
 exports.default = function () {
-  var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee() {
-    return regeneratorRuntime.wrap(function _callee$(_context) {
+  var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee() {
+    return _regenerator2.default.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:

--- a/example/index.js
+++ b/example/index.js
@@ -1,7 +1,3 @@
-/* eslint-disable import/no-unassigned-import */
-require('babel-core/register')
-require('babel-polyfill')
-
 if (!module.parent) {
   require('./example')()
     .catch(err => console.error(err))

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "example-rethinkdb-changefeed-reconnect",
+  "version": "1.0.0",
+  "description": "Example of using rethinkdb-changefeed-reconnect",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node ./index.js"
+  },
+  "author": "Jeffrey Wescott <jeffrey@learnersguild.org>",
+  "dependencies": {
+    "rethinkdb": "^2.3.3",
+    "rethinkdb-changefeed-reconnect": "^0.3.0",
+    "rethinkdbdash": "^2.3.27"
+  },
+  "license": "ISC"
+}

--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -1,0 +1,239 @@
+'use strict';
+
+var _promise = require('babel-runtime/core-js/promise');
+
+var _promise2 = _interopRequireDefault(_promise);
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
+var _blueTape = require('blue-tape');
+
+var _blueTape2 = _interopRequireDefault(_blueTape);
+
+var _error = require('rethinkdbdash/lib/error');
+
+var _index = require('../index');
+
+var _index2 = _interopRequireDefault(_index);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+(0, _blueTape2.default)('processChangeFeedWithAutoReconnect', function (t) {
+  var loggedArgs = null;
+  var logger = {
+    log: function log() {
+      for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+        args[_key] = arguments[_key];
+      }
+
+      loggedArgs = args;
+    },
+    info: function info() {
+      for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+        args[_key2] = arguments[_key2];
+      }
+
+      loggedArgs = args;
+    },
+    warn: function warn() {
+      for (var _len3 = arguments.length, args = Array(_len3), _key3 = 0; _key3 < _len3; _key3++) {
+        args[_key3] = arguments[_key3];
+      }
+
+      loggedArgs = args;
+    },
+    error: function error() {
+      for (var _len4 = arguments.length, args = Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
+        args[_key4] = arguments[_key4];
+      }
+
+      loggedArgs = args;
+    }
+  };
+
+  var getOptions = function getOptions(opts) {
+    return (0, _extends3.default)({
+      maxAttempts: 2,
+      silent: true,
+      attemptDelay: 10,
+      changefeedName: 'test feed',
+      logger: logger
+    }, opts);
+  };
+
+  var noOp = function noOp() {
+    return null;
+  };
+
+  var onErrorCalled = false;
+  var onError = function onError(err) {
+    if (err.message.includes('simulated')) {
+      onErrorCalled = true;
+    }
+  };
+
+  var onFeedItemCalled = false;
+  var onFeedItem = function onFeedItem(item) {
+    if (item.the === 'item') {
+      onFeedItemCalled = true;
+    }
+  };
+
+  var successfulGetFeed = function successfulGetFeed() {
+    return _promise2.default.resolve({
+      each: function each(onCursorEach) {
+        onCursorEach(null, { the: 'item' });
+      }
+    });
+  };
+
+  var nonConnectionErrorOnCursorGetFeed = function nonConnectionErrorOnCursorGetFeed() {
+    return _promise2.default.resolve({
+      each: function each(onCursorEach) {
+        onCursorEach(new Error('simulated'));
+      }
+    });
+  };
+
+  var nonConnectionErrorOnGetFeed = function nonConnectionErrorOnGetFeed() {
+    return _promise2.default.reject(new Error('simulated'));
+  };
+
+  var connectionErrorOnCursorGetFeedAttempts = 0;
+  var connectionErrorOnCursorGetFeed = function connectionErrorOnCursorGetFeed() {
+    connectionErrorOnCursorGetFeedAttempts += 1;
+    if (connectionErrorOnCursorGetFeedAttempts === 1) {
+      return _promise2.default.resolve({
+        each: function each(onCursorEach) {
+          onCursorEach(new _error.ReqlDriverError('simulated'));
+        }
+      });
+    }
+    return _promise2.default.reject(new _error.ReqlDriverError('simulated'));
+  };
+
+  var connectionErrorOnGetFeedAttempts = 0;
+  var connectionErrorOnGetFeed = function connectionErrorOnGetFeed() {
+    connectionErrorOnGetFeedAttempts += 1;
+    return _promise2.default.reject(new _error.ReqlDriverError('simulated'));
+  };
+
+  var timeoutPromise = function timeoutPromise(setup, runTests) {
+    var timeoutMillis = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 200;
+
+    return new _promise2.default(function (resolve, reject) {
+      setup();
+      setTimeout(function () {
+        try {
+          runTests();
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      }, timeoutMillis);
+    });
+  };
+
+  t.test('option: maxAttempts', function (tt) {
+    tt.test('attempts to reconnect `maxAttempts` times when connection-related errors occur', function (ttt) {
+      ttt.plan(2);
+
+      ttt.test('when trying to process the cursor', function (tttt) {
+        var options = getOptions();
+        connectionErrorOnCursorGetFeedAttempts = 0;
+        return timeoutPromise(function () {
+          return (0, _index2.default)(connectionErrorOnCursorGetFeed, noOp, noOp, options);
+        }, function () {
+          // maxAttempts + 1 because the first attempt will rightfully succeed
+          tttt.equal(connectionErrorOnCursorGetFeedAttempts, options.maxAttempts + 1, 'attempts !== maxAttempts');
+        });
+      });
+
+      ttt.test('when trying to get the feed itself', function (tttt) {
+        var options = getOptions();
+        connectionErrorOnGetFeedAttempts = 0;
+        return timeoutPromise(function () {
+          return (0, _index2.default)(connectionErrorOnGetFeed, noOp, noOp, options);
+        }, function () {
+          return tttt.equal(connectionErrorOnGetFeedAttempts, options.maxAttempts, 'attempts !== maxAttempts');
+        });
+      });
+    });
+
+    tt.test('invokes onError when maximum number of attempts has been exceeded', function (ttt) {
+      onErrorCalled = false;
+      return timeoutPromise(function () {
+        return (0, _index2.default)(connectionErrorOnGetFeed, noOp, onError, getOptions());
+      }, function () {
+        return ttt.equal(onErrorCalled, true, 'onError not called after exceeding maxAttempts');
+      });
+    });
+  });
+
+  t.test('option: attemptDelay', function (tt) {
+    tt.test('waits at least `attemptDelay` ms between each attempt', function (ttt) {
+      connectionErrorOnGetFeedAttempts = 0;
+      return timeoutPromise(function () {
+        var options = getOptions({ attemptDelay: 300, maxAttempts: 2 });
+        (0, _index2.default)(connectionErrorOnGetFeed, noOp, noOp, options);
+      }, function () {
+        return ttt.equal(connectionErrorOnGetFeedAttempts, 1, 'did not wait at least `attemptDelay` ms between each attempt');
+      });
+    });
+  });
+
+  t.test('option: silent', function (tt) {
+    tt.plan(2);
+
+    tt.test('when true', function (ttt) {
+      loggedArgs = null;
+      return timeoutPromise(function () {
+        return (0, _index2.default)(successfulGetFeed, noOp, noOp, { silent: true, logger: logger });
+      }, function () {
+        return ttt.equal(loggedArgs, null, 'logging was called when silent === true');
+      });
+    });
+
+    tt.test('when false', function (ttt) {
+      loggedArgs = null;
+      return timeoutPromise(function () {
+        return (0, _index2.default)(successfulGetFeed, noOp, noOp, { silent: false, logger: logger });
+      }, function () {
+        return ttt.equal(loggedArgs.length > 0, true, 'logging was not called when silent === false');
+      });
+    });
+  });
+
+  t.test('onError: invoked when non-connection-related errors occur', function (tt) {
+    tt.plan(2);
+
+    tt.test('when trying to process the cursor', function (ttt) {
+      onErrorCalled = false;
+      return timeoutPromise(function () {
+        return (0, _index2.default)(nonConnectionErrorOnCursorGetFeed, noOp, onError, getOptions());
+      }, function () {
+        return ttt.equal(onErrorCalled, true, 'onError not called for non-connection-related error');
+      });
+    });
+
+    tt.test('when trying to get the feed itself', function (ttt) {
+      onErrorCalled = false;
+      return timeoutPromise(function () {
+        return (0, _index2.default)(nonConnectionErrorOnGetFeed, noOp, onError, getOptions());
+      }, function () {
+        return ttt.equal(onErrorCalled, true, 'onError not called for non-connection-related error');
+      });
+    });
+  });
+
+  t.test('onFeedItem: invoked for each new feed item in the cursor', function (tt) {
+    onFeedItemCalled = false;
+    return timeoutPromise(function () {
+      return (0, _index2.default)(successfulGetFeed, onFeedItem, noOp, getOptions());
+    }, function () {
+      return tt.equal(onFeedItemCalled, true, 'onFeedItem was not called');
+    });
+  });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,11 +4,23 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _regenerator = require('babel-runtime/regenerator');
+
+var _regenerator2 = _interopRequireDefault(_regenerator);
+
+var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
+
+var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
+
+var _assign = require('babel-runtime/core-js/object/assign');
+
+var _assign2 = _interopRequireDefault(_assign);
+
 /* eslint-disable max-params */
 var _processChangeFeed = function () {
-  var _ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee(getFeed, onFeedItem, onError, options, attempts) {
+  var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(getFeed, onFeedItem, onError, options, attempts) {
     var logger, cursor;
-    return regeneratorRuntime.wrap(function _callee$(_context) {
+    return _regenerator2.default.wrap(function _callee$(_context) {
       while (1) {
         switch (_context.prev = _context.next) {
           case 0:
@@ -68,12 +80,12 @@ exports.default = processChangeFeedWithAutoReconnect;
 
 var _error = require('rethinkdbdash/lib/error');
 
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function processChangeFeedWithAutoReconnect(getFeed, onFeedItem, onError) {
   var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
 
-  options = Object.assign({}, _defaultOptions(), options);
+  options = (0, _assign2.default)({}, _defaultOptions(), options);
   _processChangeFeedWithAutoReconnect(getFeed, onFeedItem, onError, options);
 }
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
   },
   "nyc": {
     "sourceMap": false,
-    "instrument": false
+    "instrument": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,19 +1,22 @@
 {
   "name": "rethinkdb-changefeed-reconnect",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "automatically reconnect changefeed processors when connection is lost",
   "main": "lib",
   "scripts": {
-    "build:library": "./node_modules/.bin/babel -d lib/ src/ --ignore __tests__",
-    "build:example": "./node_modules/.bin/babel example/example.babel.js > example/example.js",
     "build": "npm run build:library && npm run build:example",
-    "prepublish": "npm test && npm run build",
+    "build:library": "npm run clean:library && ./node_modules/.bin/babel -d lib/ src/",
+    "build:example": "npm run clean:example && ./node_modules/.bin/babel ./example/example.babel.js > ./example/example.js",
+    "clean": "npm run clean:library && npm run clean:example",
+    "clean:library": "./node_modules/.bin/rimraf ./lib/*",
+    "clean:example": "./node_modules/.bin/rimraf ./example/example.js",
+    "prepublish": "npm run build && npm test",
     "2npm": "./node_modules/.bin/publish",
     "lint": "./node_modules/.bin/xo",
     "test:cov": "npm run test:cov:run && npm run test:cov:send",
     "test:cov:run": "./node_modules/.bin/nyc --reporter=lcov npm run test:run",
     "test:cov:send": "./node_modules/.bin/codeclimate-test-reporter < ./coverage/lcov.info",
-    "test:run": "NODE_ENV=test ./node_modules/.bin/babel-tape-runner '**/__tests__/*.test.js' | ./node_modules/.bin/faucet",
+    "test:run": "NODE_ENV=test ./node_modules/.bin/tape 'lib/**/__tests__/*.test.js' | ./node_modules/.bin/faucet",
     "test": "npm run lint && npm run test:run"
   },
   "keywords": [
@@ -31,6 +34,9 @@
     "email": "jeffrey@learnersguild.org"
   },
   "license": "ISC",
+  "dependencies": {
+    "babel-runtime": "^6.18.0"
+  },
   "peerDependencies": {
     "rethinkdb": "^2.3.3",
     "rethinkdbdash": "^2.3.25"
@@ -40,11 +46,9 @@
     "babel-core": "^6.18.2",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-istanbul": "^2.0.3",
-    "babel-polyfill": "^6.16.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-2": "^6.18.0",
-    "babel-runtime": "^6.18.0",
-    "babel-tape-runner": "^2.0.1",
     "blue-tape": "^1.0.0",
     "codeclimate-test-reporter": "^0.4.0",
     "faucet": "0.0.1",
@@ -52,6 +56,7 @@
     "publish": "^0.6.0",
     "rethinkdb": "^2.3.3",
     "rethinkdbdash": "^2.3.25",
+    "rimraf": "^2.5.4",
     "tape": "^4.6.2",
     "xo": "^0.17.0"
   },


### PR DESCRIPTION
Fixes #3.

## Overview

This library wasn't properly set up. People trying to use it would have had to have their projects using `babel-runtime` or `babel-polyfill`. This fixes that by using `babel-plugin-transform-runtime` and introducing a dependency on `babel-runtime`.

We also now transpile the tests using `babel`, just to avoid environment errors on installation.

## Environment / Configuration Changes

### dependencies

#### Added

- babel-runtime

### devDependencies

#### Added

- babel-plugin-transform-runtime

#### Removed

- babel-polyfill
- babel-runtime
- babel-tape-runner

## Notes

N/A