### PR TITLE
check for add'l errors when connecting via proxy

### DIFF
--- a/example/example.babel.js
+++ b/example/example.babel.js
@@ -6,7 +6,7 @@ import processChangefeed from '../lib'
 const TMP_DB_NAME_PREFIX = '_changefeedReconnectTest_'
 const tmpDbName = `${TMP_DB_NAME_PREFIX}${Date.now()}`
 const tableName = 'changefeedItems'
-const r = rethinkdbdash({servers: {host: 'localhost', port: 28015}, silent: true})
+const r = rethinkdbdash({servers: [{host: 'localhost', port: 28015}], silent: true})
 
 export default async function go() {
   try {
@@ -18,7 +18,7 @@ export default async function go() {
     processChangefeed(getFeed, handleFeedItem, handleError, {
       changefeedName: `${tmpDbName}-${tableName} feed`,
       attemptDelay: 3000,
-      maxAttempts: 3,
+      maxAttempts: 30,
       silent: false,
     })
   } catch (err) {
@@ -30,6 +30,8 @@ function getFeed() {
   return r
     .db(tmpDbName)
     .table(tableName)
+    .orderBy({index: r.desc('updatedAt')})
+    .limit(3)
     .changes()
     .filter(r.row('old_val').eq(null))
 }
@@ -54,5 +56,7 @@ async function _cleanupOldTestDatabases() {
 
 async function _createTestDatabaseAndTable() {
   await r.dbCreate(tmpDbName)
-  await r.db(tmpDbName).tableCreate(tableName)
+  await r.db(tmpDbName).tableCreate(tableName) // add {replicas: XX} if on a cluster
+  await r.db(tmpDbName).table(tableName).indexCreate('updatedAt')
+  await r.db(tmpDbName).table(tableName).indexWait()
 }

--- a/example/example.js
+++ b/example/example.js
@@ -65,6 +65,14 @@ var _createTestDatabaseAndTable = function () {
             return r.db(tmpDbName).tableCreate(tableName);
 
           case 4:
+            _context3.next = 6;
+            return r.db(tmpDbName).table(tableName).indexCreate('updatedAt');
+
+          case 6:
+            _context3.next = 8;
+            return r.db(tmpDbName).table(tableName).indexWait();
+
+          case 8:
           case 'end':
             return _context3.stop();
         }
@@ -91,7 +99,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var TMP_DB_NAME_PREFIX = '_changefeedReconnectTest_';
 var tmpDbName = '' + TMP_DB_NAME_PREFIX + Date.now();
 var tableName = 'changefeedItems';
-var r = (0, _rethinkdbdash2.default)({ servers: { host: 'localhost', port: 28015 }, silent: true });
+var r = (0, _rethinkdbdash2.default)({ servers: [{ host: 'localhost', port: 28015 }], silent: true });
 
 exports.default = function () {
   var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee() {
@@ -113,7 +121,7 @@ exports.default = function () {
             (0, _lib2.default)(getFeed, handleFeedItem, handleError, {
               changefeedName: tmpDbName + '-' + tableName + ' feed',
               attemptDelay: 3000,
-              maxAttempts: 3,
+              maxAttempts: 30,
               silent: false
             });
             _context.next = 11;
@@ -141,7 +149,7 @@ exports.default = function () {
 }();
 
 function getFeed() {
-  return r.db(tmpDbName).table(tableName).changes().filter(r.row('old_val').eq(null));
+  return r.db(tmpDbName).table(tableName).orderBy({ index: r.desc('updatedAt') }).limit(3).changes().filter(r.row('old_val').eq(null));
 }
 
 function handleFeedItem(_ref2) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,6 +173,10 @@ function _defaultOptions() {
 }
 
 function _isConnectionError(err) {
-  return err instanceof _error.ReqlServerError || err instanceof _error.ReqlDriverError;
+  // FIXME: I'm not terribly happy about this particular logic, but
+  // unfortunately, rethinkdbdash doesn't provide a consistent error type (or
+  // even message) when it's having trouble connecting to a changefeed,
+  // particularly if it is connecting via a rethinkdb proxy server.
+  return err instanceof _error.ReqlServerError || err instanceof _error.ReqlDriverError || err.msg && err.msg.match(/Changefeed\saborted/) || err.msg && err.msg.match(/primary\sreplica.*not\savailable/);
 }
 module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rethinkdb-changefeed-reconnect",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "automatically reconnect changefeed processors when connection is lost",
   "main": "lib",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -80,5 +80,12 @@ function _defaultOptions() {
 }
 
 function _isConnectionError(err) {
-  return (err instanceof ReqlServerError) || (err instanceof ReqlDriverError)
+  // FIXME: I'm not terribly happy about this particular logic, but
+  // unfortunately, rethinkdbdash doesn't provide a consistent error type (or
+  // even message) when it's having trouble connecting to a changefeed,
+  // particularly if it is connecting via a rethinkdb proxy server.
+  return (err instanceof ReqlServerError) ||
+    (err instanceof ReqlDriverError) ||
+    (err.msg && err.msg.match(/Changefeed\saborted/)) ||
+    (err.msg && err.msg.match(/primary\sreplica.*not\savailable/))
 }


### PR DESCRIPTION
Fixes #5 .

## Overview

When connecting through a proxy, the connection errors may not necessarily be of type `ReqlServerError` or `ReqlDriverError`, so we had to add additional matching (gross) based on the error message.

## Environment / Configuration Changes

N/A

## Notes

N/A