### PR TITLE
Match "The connection was closed"-error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,5 +87,6 @@ function _isConnectionError(err) {
   return (err instanceof ReqlServerError) ||
     (err instanceof ReqlDriverError) ||
     (err.msg && err.msg.match(/Changefeed\saborted/)) ||
-    (err.msg && err.msg.match(/primary\sreplica.*not\savailable/))
+    (err.msg && err.msg.match(/primary\sreplica.*not\savailable/)) ||
+    (err.msg && err.msg.match(/connection\swas\sclosed/))
 }


### PR DESCRIPTION
## Overview

Updates the `_isConnectionError` method to match more errors.

## Environment / Configuration Changes

N/A

## Notes

I'm sorry to have to open the #5 can of worms again but we're getting these errors when the server crashes and the changefeed disconnects:

![](https://i.imgur.com/3oVFN1v.png)

I've updated the `_isConnectionError` method to also match that error.